### PR TITLE
Fix for ingame cursor, which is appearing as a black square

### DIFF
--- a/source/hooks.c
+++ b/source/hooks.c
@@ -379,33 +379,34 @@ static int WINAPI StretchDIBits_fn(  //
     UINT iUsage,
     DWORD rop)
 {
-  if (hdc != last_device_context || hit_count != 2) {
-    {
-      struct scaled scaled = scale(&DestWidth, &DestHeight);
-      DestWidth = scaled.a;
-      DestHeight = scaled.b;
-    }
+  if (iUsage != 0) {
+    if (hdc != last_device_context || hit_count != 2) {
+      {
+        struct scaled scaled = scale(&DestWidth, &DestHeight);
+        DestWidth = scaled.a;
+        DestHeight = scaled.b;
+      }
 
-    xDest -= screen->half_width;
-    yDest -= screen->half_height;
-
-    {
-      int x_sign = xDest < 0 ? -1 : 1;
-      int y_sign = yDest < 0 ? -1 : 1;
-      xDest *= x_sign;
-      yDest *= y_sign;
+      xDest -= screen->half_width;
+      yDest -= screen->half_height;
 
       {
-        struct scaled scaled = scale(&xDest, &yDest);
-        xDest = scaled.a * x_sign;
-        yDest = scaled.b * y_sign;
+        int x_sign = xDest < 0 ? -1 : 1;
+        int y_sign = yDest < 0 ? -1 : 1;
+        xDest *= x_sign;
+        yDest *= y_sign;
+
+        {
+          struct scaled scaled = scale(&xDest, &yDest);
+          xDest = scaled.a * x_sign;
+          yDest = scaled.b * y_sign;
+        }
       }
+
+      xDest += screen->half_width;
+      yDest += screen->half_height;
     }
-
-    xDest += screen->half_width;
-    yDest += screen->half_height;
   }
-
   return StretchDIBits_ptr(  //
       hdc,
       xDest,


### PR DESCRIPTION
I haven't investigated why this fix works or why the issue occurs in the first place.
But on my Windows 11 setup, the in-game cursor appears as a black square (as shown in the attached image).

![image](https://github.com/user-attachments/assets/316f3f12-bfb3-4410-9f35-4d3c1013d3eb)

Capturing a screenshot turned out to be problematic. When the application loses focus, the cursor vanishes.

- Using OBS Studio for screen recording; the cursor appeared correctly in the video... despite being black on screen
- When using the Windows Game Bar, the cursor in video was offset from its actual position. It should have been near the middle of the window but appeared closer to the bottom right, but was the black square.
